### PR TITLE
Changed link in the finalization notification to the person informati…

### DIFF
--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -2016,9 +2016,9 @@ class CoPetition extends AppModel {
                       ActionEnum::CoPetitionUpdated,
                       $comment,
                       array(
-                        'controller' => 'co_petitions',
-                        'action'     => 'view',
-                        'id'         => $id
+                        'controller' => 'co_people',
+                        'action'     => 'canvas',
+                        'id'         => $pt['CoPetition']['enrollee_co_person_id']
                       ),
                       false,
                       $pt['CoEnrollmentFlow']['notify_from'],


### PR DESCRIPTION
Changed link in the finalization notification to the person information overview, instead of to the petition, as the latter is privileged and will cause a permission denied error