### PR TITLE
Fixed session-content problem by reloading the user information on ea…

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -47,7 +47,8 @@ class AppController extends Controller {
                              'Role',
                              'Security',
                              'Session',
-                             'Paginator');
+                             'Paginator',
+                             'Login');
   
   // We should probably add helpers here instead of in each Controller. To do so,
   // make sure to define the default Html and Form helpers (and Flash).
@@ -216,6 +217,10 @@ class AppController extends Controller {
       } else {
         $this->set('vv_tz', date_default_timezone_get());
       }
+
+      // Check the session user info, which could have changed due to 
+      // collaborative work on petitions, group assignments, etc.
+      $this->Login->process();
 
       // Before we do anything else, check to see if a CO was provided.
       // (It might impact our authz decisions.) Note that some models (eg: MVPAs)

--- a/app/Controller/Component/Auth/RemoteUserAuthenticate.php
+++ b/app/Controller/Component/Auth/RemoteUserAuthenticate.php
@@ -50,10 +50,10 @@ class RemoteUserAuthenticate extends BaseAuthenticate {
       return false;
     }
     
-    // We only populate username here... it's up to UsersController to populate
+    // We only populate username here... it's up to Login->process to populate
     // any other user information
     $ret['username'] = $u;
     
     return($ret);
-  }
+  }  
 }

--- a/app/Controller/Component/LoginComponent.php
+++ b/app/Controller/Component/LoginComponent.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * COmanage Registry Login Component
+ *
+ * Portions licensed to the University Corporation for Advanced Internet
+ * Development, Inc. ("UCAID") under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * UCAID licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * @link          http://www.internet2.edu/comanage COmanage Project
+ * @package       registry
+ * @since         COmanage Registry vTODO
+ * @license       Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+ 
+class LoginComponent extends Component {
+    public $components = array("Session");
+
+    public function process()
+    {
+      // At this point, Auth.User.username has been established by the Auth
+      // Controller, but nothing else. We now populate the rest of the user's
+      // session auth information.
+      CakeLog::write('debug','login process');    
+      $u = $this->Session->read('Auth.User.username');
+        
+      if(!empty($u)) {
+        // This is an Org Identity. Figure out which Org Identities this username
+        // (identifier) is associated with. First, pull the identifiers.
+        CakeLog::write('debug','searching for org identity '.$u);
+        // We use $oargs here instead of $args because we may reuse this below
+        $oargs = array();
+        $oargs['joins'][0]['table'] = 'identifiers';
+        $oargs['joins'][0]['alias'] = 'Identifier';
+        $oargs['joins'][0]['type'] = 'INNER';
+        $oargs['joins'][0]['conditions'][0] = 'OrgIdentity.id=Identifier.org_identity_id';
+        $oargs['conditions']['Identifier.identifier'] = $u;
+        $oargs['conditions']['Identifier.login'] = true;
+        // Join on identifiers that aren't deleted (including if they have no status)
+        $oargs['conditions']['OR'][] = 'Identifier.status IS NULL';
+        $oargs['conditions']['OR'][]['Identifier.status <>'] = StatusEnum::Deleted;
+        // As of v2.0.0, OrgIdentities have validity dates, so only accept valid dates (if specified)
+        // Through the magic of containable behaviors, we can get all the associated
+        $oargs['conditions']['AND'][] = array(
+          'OR' => array(
+            'OrgIdentity.valid_from IS NULL',
+            'OrgIdentity.valid_from < ' => date('Y-m-d H:i:s', time())
+          )
+        );
+        $oargs['conditions']['AND'][] = array(
+          'OR' => array(
+            'OrgIdentity.valid_through IS NULL',
+            'OrgIdentity.valid_through > ' => date('Y-m-d H:i:s', time())
+          )
+        );
+        // data we need in one clever find
+        $oargs['contain'][] = 'PrimaryName';
+        $oargs['contain'][] = 'Identifier';
+        $oargs['contain']['CoOrgIdentityLink']['CoPerson'][0] = 'Co';
+        $oargs['contain']['CoOrgIdentityLink']['CoPerson'][1] = 'CoPersonRole';
+        $oargs['contain']['CoOrgIdentityLink']['CoPerson']['CoGroupMember'] = 'CoGroup';
+            
+        $OrgIdentity = ClassRegistry::init("OrgIdentity");
+        $orgIdentities = $OrgIdentity->find('all', $oargs);
+        CakeLog::write('debug','found '.json_encode($orgIdentities));
+            
+        // Grab the org IDs and CO information
+        $orgs = array();
+        $cos = array();
+            
+        // Determine if we are collecting authoritative attributes from $ENV
+        // (the only support mechanism at the moment). If so, this will be an array
+        // of those value. If not, false.
+        $CmpEnrollmentConfiguration = ClassRegistry::init("CmpEnrollmentConfiguration");
+        $envValues = $CmpEnrollmentConfiguration->enrollmentAttributesFromEnv();
+            
+        if(!empty($envValues)) {
+          // Walk through the Org Identities and update any configured/collected attributes.
+          // Track if we made any changes.
+          $orgIdentityChanged = false;
+              
+          foreach($orgIdentities as $o) {
+            if(!empty($o['Identifier'])) {
+              // Does this org identity's identifier match the authenticated identifier?
+                  
+              foreach($o['Identifier'] as $i) {
+                if(isset($i['login']) && $i['login']
+                   && !empty($i['status']) && $i['status'] == StatusEnum::Active
+                   && !empty($i['identifier'])
+                   && $i['identifier'] == $u) {
+                  // We have a match, possibly update associated attributes
+                  $newOrgIdentity = $OrgIdentity->updateFromEnv($o['OrgIdentity']['id'], $envValues);
+                      
+                  if(!empty($newOrgIdentity)) {
+                    // Update our session store with the new values
+                    $orgIdentityChanged = true;
+                  }
+                      
+                  // No need to walk through any other identifiers attached to this org identity
+                  break;
+                }
+              }
+            }
+          }
+              
+          if($orgIdentityChanged) {
+            // Simply reread the org identities... this is easier than trying to
+            // collate the new identity into the old one. (We don't track all potentially
+            // updated attributes in the session.)
+            $orgIdentities = $OrgIdentity->find('all', $oargs);
+          }
+        }
+            
+        foreach($orgIdentities as $o) {
+          $orgs[] = array(
+            'org_id' => $o['OrgIdentity']['id'],
+            'co_id' => $o['OrgIdentity']['co_id']
+          );
+              
+          foreach($o['CoOrgIdentityLink'] as $l)
+          {
+            // If org identities are pooled, OrgIdentity:co_id will be null, so look at
+            // the identity links to get the COs (via CO Person).
+            
+            $cos[ $l['CoPerson']['Co']['name'] ] = array(
+              'co_id' => $l['CoPerson']['Co']['id'],
+              'co_name' => $l['CoPerson']['Co']['name'],
+              'co_person_id' => $l['co_person_id'],
+              'co_person' => $l['CoPerson']
+            );
+                
+            // And assemble the Group Memberships
+            $params = array(
+              'conditions' => array(
+                'CoGroupMember.co_person_id' => $l['co_person_id']
+              ),
+              'contain' => false
+            );
+            $CoGroupMember = ClassRegistry::init("CoGroupMember");
+            $CoGroup = ClassRegistry::init("CoGroup");
+            $memberships = $CoGroupMember->find('all', $params);
+                
+            foreach($memberships as $m){
+              $params = array(
+                'conditions' => array(
+                  'CoGroup.id' => $m['CoGroupMember']['co_group_id']
+                )
+              );
+              $result = $CoGroup->find('first', $params);
+                  
+              if(!empty($result)) {
+                $group = $result['CoGroup'];
+                
+                $cos[ $l['CoPerson']['Co']['name'] ]['groups'][ $group['name'] ] = array(
+                  'co_group_id' => $m['CoGroupMember']['co_group_id'],
+                  'name' => $group['name'],
+                  'member' => $m['CoGroupMember']['member'],
+                  'owner' => $m['CoGroupMember']['owner']
+                );
+              }
+            }
+          }
+        }
+            
+        $this->Session->write('Auth.User.org_identities', $orgs);
+        $this->Session->write('Auth.User.cos', $cos);
+            
+        // Use the primary organizational name as the session name.
+        if(isset($orgIdentities[0]['PrimaryName'])) {
+          $this->Session->write('Auth.User.name', $orgIdentities[0]['PrimaryName']);
+        }
+            
+        // Determine if there are any pending T&Cs
+        foreach($cos as $co) {
+          // First see if T&Cs are enforced at login for this CO
+          $CoSetting = ClassRegistry::init("CoSetting");
+          $CoTermsAndConditions = ClassRegistry::init("CoTermsAndConditions");
+          if($CoSetting->getTAndCLoginMode($co['co_id']) == TAndCLoginModeEnum::RegistryLogin) {
+            $pending = $CoTermsAndConditions->pending($co['co_person_id']);
+                
+            if(!empty($pending)) {
+              // Store the pending T&C in the session so that beforeFilter() can check it.
+              // This isn't ideal, but should be preferable to beforeFilter performing the
+              // check before every action. It also means T&C are enforced once per login
+              // rather than if the T&C change in the middle of a user's session.
+              $this->Session->write('Auth.User.tandc.pending.' . $co['co_id'], $pending);
+            }
+          }
+        }
+        return true;
+      }
+      return false;
+    }
+    
+    public function record()
+    {
+      $u = $this->Session->read('Auth.User.username');
+          
+      if(!empty($u)) {
+        $AuthenticationEvent = ClassRegistry::init("AuthenticationEvent");
+        $AuthenticationEvent->record($u, AuthenticationEventEnum::RegistryLogin, $_SERVER['REMOTE_ADDR']);
+      }
+    }
+}    

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -27,14 +27,6 @@
 
 class UsersController extends AppController {
   public $name = 'Users';
-  
-  public $uses = array("AuthenticationEvent",
-                       "CmpEnrollmentConfiguration",
-                       "CoGroup",
-                       "CoGroupMember",
-                       "CoSetting",
-                       "CoTermsAndConditions",
-                       "OrgIdentity");
 
   public $components = array(
     'Auth' => array(
@@ -43,7 +35,8 @@ class UsersController extends AppController {
       )
     ),
     'RequestHandler',
-    'Session'
+    'Session',
+    'Login'
   );
   
   /**
@@ -86,187 +79,15 @@ class UsersController extends AppController {
   
   public function login() {
     if($this->Auth->login()) {
-      // At this point, Auth.User.username has been established by the Auth
-      // Controller, but nothing else. We now populate the rest of the user's
-      // session auth information.
-      
-      $u = $this->Session->read('Auth.User.username');
-      
-      if(!empty($u)) {
-        if(!$this->Session->check('Auth.User.api_user_id')) {
-          // This is an Org Identity. Figure out which Org Identities this username
-          // (identifier) is associated with. First, pull the identifiers.
-          
-          // We use $oargs here instead of $args because we may reuse this below
-          $oargs = array();
-          $oargs['joins'][0]['table'] = 'identifiers';
-          $oargs['joins'][0]['alias'] = 'Identifier';
-          $oargs['joins'][0]['type'] = 'INNER';
-          $oargs['joins'][0]['conditions'][0] = 'OrgIdentity.id=Identifier.org_identity_id';
-          $oargs['conditions']['Identifier.identifier'] = $u;
-          $oargs['conditions']['Identifier.login'] = true;
-          // Join on identifiers that aren't deleted (including if they have no status)
-          $oargs['conditions']['OR'][] = 'Identifier.status IS NULL';
-          $oargs['conditions']['OR'][]['Identifier.status <>'] = StatusEnum::Deleted;
-          // As of v2.0.0, OrgIdentities have validity dates, so only accept valid dates (if specified)
-          // Through the magic of containable behaviors, we can get all the associated
-          $oargs['conditions']['AND'][] = array(
-            'OR' => array(
-              'OrgIdentity.valid_from IS NULL',
-              'OrgIdentity.valid_from < ' => date('Y-m-d H:i:s', time())
-            )
-          );
-          $oargs['conditions']['AND'][] = array(
-            'OR' => array(
-              'OrgIdentity.valid_through IS NULL',
-              'OrgIdentity.valid_through > ' => date('Y-m-d H:i:s', time())
-            )
-          );
-          // data we need in one clever find
-          $oargs['contain'][] = 'PrimaryName';
-          $oargs['contain'][] = 'Identifier';
-          $oargs['contain']['CoOrgIdentityLink']['CoPerson'][0] = 'Co';
-          $oargs['contain']['CoOrgIdentityLink']['CoPerson'][1] = 'CoPersonRole';
-          $oargs['contain']['CoOrgIdentityLink']['CoPerson']['CoGroupMember'] = 'CoGroup';
-          
-          $orgIdentities = $this->OrgIdentity->find('all', $oargs);
-          
-          // Grab the org IDs and CO information
-          $orgs = array();
-          $cos = array();
-          
-          // Determine if we are collecting authoritative attributes from $ENV
-          // (the only support mechanism at the moment). If so, this will be an array
-          // of those value. If not, false.
-          $envValues = $this->CmpEnrollmentConfiguration->enrollmentAttributesFromEnv();
-          
-          if(!empty($envValues)) {
-            // Walk through the Org Identities and update any configured/collected attributes.
-            // Track if we made any changes.
-            
-            $orgIdentityChanged = false;
-            
-            foreach($orgIdentities as $o) {
-              if(!empty($o['Identifier'])) {
-                // Does this org identity's identifier match the authenticated identifier?
-                
-                foreach($o['Identifier'] as $i) {
-                  if(isset($i['login']) && $i['login']
-                     && !empty($i['status']) && $i['status'] == StatusEnum::Active
-                     && !empty($i['identifier'])
-                     && $i['identifier'] == $u) {
-                    // We have a match, possibly update associated attributes
-                    
-                    $newOrgIdentity = $this->OrgIdentity->updateFromEnv($o['OrgIdentity']['id'], $envValues);
-                    
-                    if(!empty($newOrgIdentity)) {
-                      // Update our session store with the new values
-                      
-                      $orgIdentityChanged = true;
-                    }
-                    
-                    // No need to walk through any other identifiers attached to this org identity
-                    break;
-                  }
-                }
-              }
-            }
-            
-            if($orgIdentityChanged) {
-              // Simply reread the org identities... this is easier than trying to
-              // collate the new identity into the old one. (We don't track all potentially
-              // updated attributes in the session.)
-              
-              $orgIdentities = $this->OrgIdentity->find('all', $oargs);
-            }
-          }
-          
-          foreach($orgIdentities as $o) {
-            $orgs[] = array(
-              'org_id' => $o['OrgIdentity']['id'],
-              'co_id' => $o['OrgIdentity']['co_id']
-            );
-            
-            foreach($o['CoOrgIdentityLink'] as $l)
-            {
-              // If org identities are pooled, OrgIdentity:co_id will be null, so look at
-              // the identity links to get the COs (via CO Person).
-              
-              $cos[ $l['CoPerson']['Co']['name'] ] = array(
-                'co_id' => $l['CoPerson']['Co']['id'],
-                'co_name' => $l['CoPerson']['Co']['name'],
-                'co_person_id' => $l['co_person_id'],
-                'co_person' => $l['CoPerson']
-              );
-              
-              // And assemble the Group Memberships
-              
-              $params = array(
-                'conditions' => array(
-                  'CoGroupMember.co_person_id' => $l['co_person_id']
-                ),
-                'contain' => false
-              );
-              $memberships = $this->CoGroupMember->find('all', $params);
-              
-              foreach($memberships as $m){
-                $params = array(
-                  'conditions' => array(
-                    'CoGroup.id' => $m['CoGroupMember']['co_group_id']
-                  )
-                );
-                $result = $this->CoGroup->find('first', $params);
-                
-                if(!empty($result)) {
-                  $group = $result['CoGroup'];
-                  
-                  $cos[ $l['CoPerson']['Co']['name'] ]['groups'][ $group['name'] ] = array(
-                    'co_group_id' => $m['CoGroupMember']['co_group_id'],
-                    'name' => $group['name'],
-                    'member' => $m['CoGroupMember']['member'],
-                    'owner' => $m['CoGroupMember']['owner']
-                  );
-                }
-              }
-            }
-          }
-          
-          $this->Session->write('Auth.User.org_identities', $orgs);
-          $this->Session->write('Auth.User.cos', $cos);
-          
-          // Use the primary organizational name as the session name.
-          
-          if(isset($orgIdentities[0]['PrimaryName'])) {
-            $this->Session->write('Auth.User.name', $orgIdentities[0]['PrimaryName']);
-          }
-          
-          // Determine if there are any pending T&Cs
-          
-          foreach($cos as $co) {
-            // First see if T&Cs are enforced at login for this CO
-            
-            if($this->CoSetting->getTAndCLoginMode($co['co_id']) == TAndCLoginModeEnum::RegistryLogin) {
-              $pending = $this->CoTermsAndConditions->pending($co['co_person_id']);
-              
-              if(!empty($pending)) {
-                // Store the pending T&C in the session so that beforeFilter() can check it.
-                // This isn't ideal, but should be preferable to beforeFilter performing the
-                // check before every action. It also means T&C are enforced once per login
-                // rather than if the T&C change in the middle of a user's session.
-                
-                $this->Session->write('Auth.User.tandc.pending.' . $co['co_id'], $pending);
-              }
-            }
-          }
-          
+      if(!$this->Session->check('Auth.User.api_user_id')) {
+        if($this->Login->process()) {
           // Determine last login for the identifier. Do this before we record
           // the current login. We don't currently check identifiers associated with
           // other Org Identities because doing so would be a bit challenging...
           // we're logging in at a platform level, which COs do we query? For now,
           // someone who wants more login details can view them via their canvas.
-          
           $lastlogins = array();
-          
+                
           if(!empty($orgIdentities[0]['Identifier'])) {
             foreach($orgIdentities[0]['Identifier'] as $id) {
               if(!empty($id['identifier']) && isset($id['login']) && $id['login']) {
@@ -274,21 +95,21 @@ class UsersController extends AppController {
               }
             }
           }
-          
+                
           $this->Session->write('Auth.User.lastlogin', $lastlogins);
-          
+                
           // Record the login
-          $this->AuthenticationEvent->record($u, AuthenticationEventEnum::RegistryLogin, $_SERVER['REMOTE_ADDR']);
-          
-          $this->redirect($this->Auth->redirectUrl());
+          $this->Login->record();
+                
+          $this->redirect($this->Auth->redirectUrl());            
         } else {
-          // This is an API user. We don't do anything special at the moment, other
-          // than record the login event
-          
-          $this->AuthenticationEvent->record($u, AuthenticationEventEnum::ApiLogin, $_SERVER['REMOTE_ADDR']);
+          throw new RuntimeException(_txt('er.auth.empty'));
         }
-      } else {
-        throw new RuntimeException(_txt('er.auth.empty'));
+      }
+      else {
+        // This is an API user. We don't do anything special at the moment, other
+        // than record the login event          
+        $this->Login->record();
       }
     } else {
       // We're probably here because the session timed out


### PR DESCRIPTION
This fix introduces a Login component with a process method. This method is called in the AppController beforeFilter method, which effectively reloads all user info for non-REST operations on each page load, instead of only when the login action succeeds.
The method is also called in the UserController::login method, when login has been approved. The Login::record method is only called at that point in the end, so it could be moved back to the UserController. I moved it out, because I anticipated another location to store the login-time, but in the end that was not necessary.