### PR TITLE
Fix for self-signup enrollment flows that want to use an OIS plugin i…

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -982,16 +982,18 @@ class CoPetitionsController extends StandardController {
         );
         
         // If we're in an unauthenticated flow, we need to append a token.
-        $token = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $id));
+        $enrolleeToken = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $id));
+        $petitionerToken = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $id));
+
+        if($action == "collectIdentifierIdentify") {
+          $token = empty($enrolleeToken) ? $petitionerToken : $enrolleeToken;
+        }
+        else {
+          $token = empty($petitionerToken) ? $enrolleeToken : $petitionerToken; 
+        }
         
         if($token) {
           $redirect['token'] = $token;
-        } else {
-          $token = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $id));
-          
-          if($token) {
-            $redirect['token'] = $token;
-          }
         }
 
         $this->redirect($redirect);

--- a/app/Plugin/EnvSource/Controller/EnvSourceCoPetitionsController.php
+++ b/app/Plugin/EnvSource/Controller/EnvSourceCoPetitionsController.php
@@ -51,11 +51,12 @@ class EnvSourceCoPetitionsController extends CoPetitionsController {
     $noAuth = false;
     
     // For self signup, we simply require a token (and for the token to match).
-    $token = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $this->parseCoPetitionId()));
+    $petitionerToken = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $this->parseCoPetitionId()));
+    $enrolleeToken = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $this->parseCoPetitionId()));
     $passedToken = $this->parseToken();
-    
-    if($token && $token != '' && $passedToken) {
-      if($token == $passedToken) {
+
+    if(!(empty($petitionerToken) && empty($enrolleeToken)) && !empty($passedToken)) {
+      if($enrolleeToken == $passedToken || $petitionerToken == $passedToken) {
         // If we were passed a reauth flag, we require authentication even though
         // the token matched. This enables account linking.
         if(!isset($this->request->params['named']['reauth'])


### PR DESCRIPTION
Fix to accompany the use of the SamlSource plugin. This fix allows using 'EnrolleeToken' instead of 'PetitionerToken' during the 'collectIdentifier' step in the provisioning flow. This PR was submitted upstream separately as well.