### PR TITLE
[finishes #157593786] Fix to skip a history record in case of a faile…

### DIFF
--- a/app/Model/OrgIdentitySource.php
+++ b/app/Model/OrgIdentitySource.php
@@ -1444,6 +1444,7 @@ class OrgIdentitySource extends AppModel {
                                                      null,
                                                      null,
                                                      JobStatusEnum::Failed);
+        continue;
       }
       
       $this->Co->CoJob->CoJobHistoryRecord->record($jobId,


### PR DESCRIPTION
Added a continue statement in the catch handler. If the OIS module that is invoked does not support the given Full-synchronisation method, it throws a domain exception, which prevents sourceKeys and knownKeys from being set. There is no need to continue with the notice and the loop over newKeys. The notice throws a warning (undefined variables, sourceKeys and knownKeys are out of scope) and newKeys is always empty.