### PR TITLE
157189342 add sshkey attribute

### DIFF
--- a/app/Controller/CoEnrollmentAttributesController.php
+++ b/app/Controller/CoEnrollmentAttributesController.php
@@ -62,7 +62,6 @@ class CoEnrollmentAttributesController extends StandardController {
   
   function add() {
     if(!empty($this->request->data)) {
-      $this->clearUnassociatedRequestData();
       
       if(!isset($this->request->data['CoEnrollmentAttribute']['ordr'])
          || $this->request->data['CoEnrollmentAttribute']['ordr'] == '') {

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -668,7 +668,7 @@ original notification at
     SshKeyTypeEnum::RSA      => 'RSA',
     SshKeyTypeEnum::RSA1     => 'RSA1'
   ),
-  
+
   'en.status' =>      array(StatusEnum::Active              => 'Active',
                             StatusEnum::Approved            => 'Approved',
                             StatusEnum::Confirmed           => 'Confirmed',
@@ -796,7 +796,7 @@ original notification at
     UrlEnum::Official => 'Official',
     UrlEnum::Personal => 'Personal',
   ),
-  
+
   'en.visibility' => array(
     VisibilityEnum::CoAdmin         => 'CO Admin',
     VisibilityEnum::CoGroupMember   => 'CO Group Member',
@@ -1473,6 +1473,13 @@ original notification at
   'fd.url.url' =>     'URL',
   'fd.url.url.desc' => 'URL, including protocol (ie: http://myvo.org, not just myvo.org)',
   'fd.url' =>         'URL',
+  'fd.ssh_key' =>     'SSH Key',
+  'fd.ssh_key.comment' => 'Comment',
+  'fd.ssh_key.comment.desc' =>     'Description of this SSH key',
+  'fd.ssh_key.type' => 'Key type',
+  'fd.ssh_key.type.desc' =>     'Type of key',
+  'fd.ssh_key.skey' => 'SSH Key',
+  'fd.ssh_key.skey.desc' =>     'SSH key content',
   'fd.username.api' => 'API User Name',
   'fd.valid_from' =>  'Valid From',
   'fd.valid_from.desc' => 'Leave blank for immediate validity',

--- a/app/View/CoPetitions/petition-attributes.inc
+++ b/app/View/CoPetitions/petition-attributes.inc
@@ -118,6 +118,61 @@
     //$(":submit").attr('disabled', true);
   }
 <?php endif; ?>
+
+  $(document).ready(function() {
+    $('.field-p_ssh_key-skey').on('change',function() {      
+        // check to see if the pasted text by chance contains a full SSH authorized key,
+        // including a type and a comment. If so, parse it and set the comment and type
+        // fields instead
+        var value = $.trim($(this).val());
+
+        var typeToCO = {
+          "ssh-dss": <?php echo json_encode(SshKeyTypeEnum::DSA); ?>,
+          "ssh-rsa": <?php echo json_encode(SshKeyTypeEnum::RSA); ?>,
+          "ssh-ed25519": <?php echo json_encode(SshKeyTypeEnum::ED25519); ?>,
+          "ecdsa-sha2-nistp256": <?php echo json_encode(SshKeyTypeEnum::ECDSA); ?>
+        };
+
+        if(value.indexOf(' ') !== -1) {
+          var values=value.split(' ');
+          var type = values[0];
+          var key = values.length > 1 ? values[1] : '';
+          var comment = values.length > 2 ? values[2] : '';
+          
+          // check the type and key
+          // type should be one of the ssh-<keytype> fields and key should
+          // only contain base64 characters
+          if(typeToCO[type]) {
+            $('.field-p_ssh_key-comment',$(this).parents('.modelbox-data').first()).val(comment);
+            $('.field-p_ssh_key-type',$(this).parents('.modelbox-data').first()).val(typeToCO[type]);
+            $('.field-p_ssh_key-skey',$(this).parents('.modelbox-data').first()).val(key);
+          }          
+        }
+        else if(value.match(/^[A-Za-z0-9\+\/]+=*$/) !== null) {
+          // no spaces, but we can determine the type on the base64 encoded key
+          var type=null;
+          if(value.indexOf('AAAAB3NzaC1kc3M') === 0) {
+            // ssh-dss => DSA
+            type='ssh-dss';
+          }
+          else if(value.indexOf('AAAAB3NzaC1yc2E') === 0) {
+            // ssh-rsa => RSA
+            type='ssh-rsa';
+          } 
+          else if(value.indexOf('AAAAC3NzaC1lZDI1NTE5') === 0) {
+            // ssh-ed25519
+            type='ssh-ed25519';
+          } 
+          else if(value.indexOf('AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYA') === 0) {
+            // ecdsa-sha2-nistp256
+            type='ecdsa-sha2-nistp256';
+          }
+          if(type !== null) {
+            $('.field-p_ssh_key-type',$(this).parents('.modelbox-data')).val(typeToCO[type]);
+          }
+        }
+    });
+  });
   
   $(function() {
     $("#dialog-review").dialog({
@@ -302,6 +357,9 @@
               if ($coe_attribute_index == 0) {
                 $args['class'] .= ' focusFirst';
               }
+              
+              // Add the attribute as a class type
+              $args['class'].= ' field-'.str_replace(':','_',$ea['attribute']).'-'.$ea['field'];
 
               // Render the form field, label, and error (if any)
               print $this->Form->select($fieldName, $ea['select'], $args);
@@ -381,6 +439,9 @@
               if ($coe_attribute_index == 0) {
                 $args['class'] .= ' focusFirst';
               }
+
+              // Add the attribute as a class type
+              $args['class'].= ' field-'.str_replace(':','_',$ea['attribute']).'-'.$ea['field'];
 
               $matchable = false;
               $matchableInfoId = "";

--- a/app/View/SshKeys/fields.inc
+++ b/app/View/SshKeys/fields.inc
@@ -69,13 +69,73 @@
   $this->Html->addCrumb($crumbTxt);
 
 ?>
+<?php if($e): ?>
+<script>
+  $(document).ready(function() {
+    $('#edit_ssh_key .ssh_key-skey').on('change',function() {      
+        // check to see if the pasted text by chance contains a full SSH authorized key,
+        // including a type and a comment. If so, parse it and set the comment and type
+        // fields instead
+        var value = $.trim($(this).val());
+
+        var typeToCO = {
+          "ssh-dss": <?php echo json_encode(SshKeyTypeEnum::DSA); ?>,
+          "ssh-rsa": <?php echo json_encode(SshKeyTypeEnum::RSA); ?>,
+          "ssh-ed25519": <?php echo json_encode(SshKeyTypeEnum::ED25519); ?>,
+          "ecdsa-sha2-nistp256": <?php echo json_encode(SshKeyTypeEnum::ECDSA); ?>
+        };
+
+        if(value.indexOf(' ') !== -1) {
+
+          var values=value.split(' ');
+          var type = values[0];
+          var key = values.length > 1 ? values[1] : '';
+          var comment = values.length > 2 ? values[2] : '';
+          
+          // check the type and key
+          // type should be one of the ssh-<keytype> fields and key should
+          // only contain base64 characters
+          if(typeToCO[type]) {
+            $('#edit_ssh_key .ssh_key-comment').val(comment);
+            $('#edit_ssh_key .ssh_key-type').val(typeToCO[type]);
+            $('#edit_ssh_key .ssh_key-skey').val(key);
+          }          
+        }
+        else if(value.match(/^[A-Za-z0-9\+\/]+=*$/) !== null) {
+
+          // no spaces, but we can determine the type on the base64 encoded key
+          var type=null;
+          if(value.indexOf('AAAAB3NzaC1kc3M') === 0) {
+            // ssh-dss => DSA
+            type='ssh-dss';
+          }
+          else if(value.indexOf('AAAAB3NzaC1yc2E') === 0) {
+            // ssh-rsa => RSA
+            type='ssh-rsa';
+          } 
+          else if(value.indexOf('AAAAC3NzaC1lZDI1NTE5') === 0) {
+            // ssh-ed25519
+            type='ssh-ed25519';
+          } 
+          else if(value.indexOf('AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYA') === 0) {
+            // ecdsa-sha2-nistp256
+            type='ecdsa-sha2-nistp256';
+          }
+          if(type !== null) {
+            $('#edit_ssh_key ssh_key-type').val(typeToCO[type]);
+          }
+        }
+    });
+  });
+</script>
+<?php endif; ?>
 <ul id="<?php print $this->action; ?>_ssh_key" class="fields form-list">
   <li>
     <div class="field-name">
       <?php print _txt('fd.sshkey.comment'); ?>
     </div>
     <div class="field-info">
-      <?php print ($e ? $this->Form->input('comment', array('class' => 'focusFirst')) : filter_var($ssh_keys[0]['SshKey']['comment'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
+      <?php print ($e ? $this->Form->input('comment', array('class' => 'focusFirst ssh_key-comment')) : filter_var($ssh_keys[0]['SshKey']['comment'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
     </div>
   </li>
   <li>
@@ -87,6 +147,7 @@
         global $cm_lang, $cm_texts;
         $attrs['value'] = (isset($ssh_keys) ? $ssh_keys[0]['SshKey']['type'] : SshKeyTypeEnum::DSA);
         $attrs['empty'] = false;
+        $attrs['class']='ssh_key-type';
 
         if($e) {
           print $this->Form->select('type',
@@ -107,8 +168,12 @@
       <?php print _txt('fd.sshkey.skey'); ?>
     </div>
     <div class="field-info">
-      <?php print ($e
-                   ? $this->Form->input('skey')
+      <?php
+        $attrs=array();
+        $attrs['class']='ssh_key-skey';
+ 
+        print ($e
+                   ? $this->Form->input('skey',$attrs)
                    : filter_var($ssh_keys[0]['SshKey']['skey'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
     </div>
   </li>


### PR DESCRIPTION
Quick fix for pivotal 157189342: allow SSH key during enrollment. This adds SSH key as an enrollment attribute.
Also implements some javascript to parse keys and key types, allowing the user to paste a full authorized_keys/id_rsa.pub line and have it separated into type, key and comment. Implemented both on enrollment and on key management (see CO-1616, CO-1598, CO-1087)