### PR TITLE
Merge uva into 0.5.2

### DIFF
--- a/app/Controller/CoInvitesController.php
+++ b/app/Controller/CoInvitesController.php
@@ -371,13 +371,7 @@ class CoInvitesController extends AppController {
         // supported enrollment flow involves a new Org Identity for the CO, so
         // there won't be an existing CO Person identity linked to use instead.
         // At some point (ie: additional Role enrollment; CO-310) this will change.
-        
-        $token = Security::generateAuthKey();
-        
-        $this->CoInvite->CoPetition->id = $invite['CoPetition']['id'];
-        $this->CoInvite->CoPetition->saveField('enrollee_token', $token);
-        
-        $redirect['token'] = $token;
+        $redirect['token'] = $this->CoInvite->CoPetition->ensureEnrolleeToken($invite['CoPetition']['id']);
         
         $this->redirect($redirect);
       } elseif(!empty($invite['CoInvite']['email_address_id'])) {

--- a/app/Controller/CoInvitesController.php
+++ b/app/Controller/CoInvitesController.php
@@ -140,7 +140,22 @@ class CoInvitesController extends AppController {
                                                       filter_var($this->request->params['pass'][0],FILTER_SANITIZE_SPECIAL_CHARS))));
       }
     }
-    
+    else if($this->action == "verifyEmailAddress") {
+      // verifyEmailAddress has an email address id as parameter. Use that to determine the CO
+
+      if(!empty($this->request->params['named']['email_address_id'])) {
+        $args = array();
+        $args['conditions']['EmailAddress.id'] = $this->request->params['named']['email_address_id'];
+        $args['contain'] = array('CoPerson');
+
+        $ea = $this->CoInvite->CoPerson->EmailAddress->find('first', $args);
+
+        if(!empty($ea) && !empty($ea['CoPerson'])) {
+          return $ea['CoPerson']['co_id'];
+        }
+      }
+    }
+
     if($this->action == "send" && !empty($this->request->params['named']['copersonid'])) {
       $coId = $this->CoInvite->CoPerson->field('co_id',
                                                array('id' => $this->request->params['named']['copersonid']));

--- a/app/Controller/CoInvitesController.php
+++ b/app/Controller/CoInvitesController.php
@@ -395,9 +395,26 @@ class CoInvitesController extends AppController {
         $this->Flash->set($confirm ? _txt('rs.inv.conf') : _txt('rs.inv.dec'), array('key' => 'success'));
       }
       
-      // If a login identifier was provided, force a logout
+      // If a login identifier was provided, redirect to a meaningful page
       if($loginIdentifier) {
-        $this->redirect("/auth/logout");
+        if(!empty($invite['CoInvite']['email_address_id'])) {
+          // if we confirmed an address, review the final result
+
+          $redirect = array(
+            'controller' => 'email_addresses',
+            'action'     => 'view',
+            $invite['CoInvite']['email_address_id']
+          );
+        } else {
+          // Else review the user information
+
+          $redirect = array(
+            'controller' => 'co_people',
+            'action'     => 'canvas',
+            $invite['CoInvite']['co_person_id']
+          );
+        }
+        $this->redirect($redirect);
       } else {
         $this->redirect("/");
       }

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -1700,30 +1700,48 @@ class CoPetitionsController extends StandardController {
    */
   
   protected function execute_sendConfirmation($id) {
-    $this->CoPetition->sendConfirmation($id, $this->Session->read('Auth.User.co_person_id'));
+
+    $ea = $this->CoPetition->needConfirmation($id);
+    if(!empty($ea)) {
+
+      $this->CoPetition->sendConfirmation($id, $ea, $this->Session->read('Auth.User.co_person_id'));
     
-    $this->CoPetition->updateStatus($id,
+      $this->CoPetition->updateStatus($id,
                                     PetitionStatusEnum::PendingConfirmation, 
                                     $this->Session->read('Auth.User.co_person_id'));
     
-    // The step is done
+      // The step is done
     
-    $debug = Configure::read('debug');
+      $debug = Configure::read('debug');
     
-    if(!$debug) {
-      $this->redirect($this->generateDoneRedirect('sendConfirmation', $id));
-    } else {
-      // We need to populate the view var to render the debug link
-      $coInviteId = $this->CoPetition->field('co_invite_id',
+      if(!$debug) {
+        $this->redirect($this->generateDoneRedirect('sendConfirmation', $id));
+      } else {
+        // We need to populate the view var to render the debug link
+        $coInviteId = $this->CoPetition->field('co_invite_id',
                                              array('CoPetition.id' => $id));
       
-      if($coInviteId) {
-        $args = array();
-        $args['conditions']['CoInvite.id'] = $coInviteId;
-        $args['contain'] = false;
+        if($coInviteId) {
+          $args = array();
+          $args['conditions']['CoInvite.id'] = $coInviteId;
+          $args['contain'] = false;
         
-        $this->set('vv_co_invite', $this->CoPetition->CoInvite->find('first', $args));
+          $this->set('vv_co_invite', $this->CoPetition->CoInvite->find('first', $args));
+        }
       }
+    }
+    else {
+
+      // there are no unconfirmed addresses left, directly proceed to processConfirmation
+      $coPersonId = $this->CoPetition->field('enrollee_co_person_id', array('CoPetition.id' => $id));
+      $this->CoPetition->updateStatus($id, PetitionStatusEnum::Confirmed, $coPersonId);
+
+      $redirect = $this->generateDoneRedirect('processConfirmation', $id);
+
+      // we need to switch from PetitionerToken to EnrolleeToken, which is normally done in the
+      // process of sending an invite and confirming it
+      $redirect['token'] = $this->CoPetition->ensureEnrolleeToken($id);
+      $this->redirect($redirect);
     }
   }
   

--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -1574,6 +1574,14 @@ class CoPetition extends AppModel {
     $coData = array();
     $coRoleData = array();
     
+    // set enrollmentflow related base data to pass basic validation
+    $requestData['EnrolleeCoPerson']['co_id'] = $petition['CoPetition']['co_id'];
+    $requestData['EnrolleeCoPerson']['status'] = StatusEnum::Pending;
+
+    // if no CoPerson available yet, trick validation using a '0'
+    $requestData['EnrolleeCoPersonRole']['co_person_id'] = empty($coPersonId) ? 0 : $coPersonId;
+    $requestData['EnrolleeCoPersonRole']['status'] = StatusEnum::Pending;
+
     // Validate the provided attributes
     
     $CmpEnrollmentConfiguration = ClassRegistry::init('CmpEnrollmentConfiguration');
@@ -1680,9 +1688,6 @@ class CoPetition extends AppModel {
     }
     
     if(!empty($coData) && !$coPersonId) {
-      // Insert some additional attributes
-      $coData['EnrolleeCoPerson']['co_id'] = $petition['CoPetition']['co_id'];
-      $coData['EnrolleeCoPerson']['status'] = StatusEnum::Pending;
       
       // Save the CO Person Data
       
@@ -1741,9 +1746,8 @@ class CoPetition extends AppModel {
     }
     
     if(!empty($coRoleData) && !$coPersonRoleId) {
-      // Insert some additional attributes
+      // Link the Role to the Person
       $coRoleData['EnrolleeCoPersonRole']['co_person_id'] = $coPersonId;
-      $coRoleData['EnrolleeCoPersonRole']['status'] = StatusEnum::Pending;
       
       // Set the current timezone for CoPersonRole::afterSave
       $this->EnrolleeCoPersonRole->setTimeZone($this->tz);
@@ -2990,6 +2994,7 @@ class CoPetition extends AppModel {
       // missing) related models.
       $errFields = $this->$pmodel->invalidFields();
       
+      $fail = false;
       if(!empty($errFields)) {
         $fail = true;
       }
@@ -2998,7 +3003,7 @@ class CoPetition extends AppModel {
       
       $v = $this->validateRelated($pmodel, $requestData, $ret, $efAttrs);
       
-      if($v) {
+      if($v && !$fail) {
         $ret = $v;
       } else {
         throw new RuntimeException(_txt('er.validation'));

--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -2018,8 +2018,8 @@ class CoPetition extends AppModel {
     
     $args = array();
     $args['conditions']['CoPetition.id'] = $id;
-    $args['contain']['CoEnrollmentFlow'] = 'CoEnrollmentFlowApprovalMessageTemplate';
-    $args['contain']['CoEnrollmentFlow'] = 'CoEnrollmentFlowFinMessageTemplate';
+    $args['contain']['CoEnrollmentFlow'][] = 'CoEnrollmentFlowApprovalMessageTemplate';
+    $args['contain']['CoEnrollmentFlow'][] = 'CoEnrollmentFlowFinMessageTemplate';
     $args['contain']['EnrolleeCoPerson'] = array('PrimaryName', 'Identifier');
     $args['contain']['EnrolleeCoPerson']['CoPersonRole'][] = 'Cou';
     $args['contain']['EnrolleeCoPerson']['CoPersonRole']['SponsorCoPerson'][] = 'PrimaryName';

--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -2210,6 +2210,62 @@ class CoPetition extends AppModel {
   }
   
   /**
+   * Checks for associated email address to find an 'unverified' one
+   *
+   * @since  COmanage Registry vTODO
+   * @param  Integer CO Petition ID
+   * @throws InvalidArgumentException
+   * @return EmailAddress address to be verified, if there are any available
+   *         null         if no associated unverified addresses are available
+   *
+   * Associated in this context means: directly associated with the Enrollee.
+   * We check the EmailAddress belonging to the Enrollee OI and COPerson.
+   * We do not check for linked addresses in any of the OrgIdentityLink records
+   * at this point
+   */
+  public function needConfirmation($id) {
+
+    $args = array();
+    $args['conditions']['CoPetition.id'] = $id;
+    $args['contain']['EnrolleeCoPerson']= array('EmailAddress');
+    $args['contain']['EnrolleeOrgIdentity'] = array('EmailAddress', 'PrimaryName');
+
+    $pt = $this->find('first', $args);
+
+    if(empty($pt)) {
+      throw new InvalidArgumentException(_txt('er.notfound', array(_txt('ct.co_petitions.1'), $id)));
+    }
+    else {
+      // check all email addresses and see if any of those are unverified
+      if(!empty($pt['EnrolleeOrgIdentity']['EmailAddress'])) {
+        foreach($pt['EnrolleeOrgIdentity']['EmailAddress'] as $em) {
+          if(!$em['verified']) {
+            return $em;
+          }
+        }
+      }
+      else {
+        throw new RuntimeException(_txt('er.orgp.nomail',
+                                   array(generateCn($pt['EnrolleeOrgIdentity']['PrimaryName']),
+                                   $pt['EnrolleeOrgIdentity']['id'])));
+      }
+
+      // check all CoPerson related email addresses
+      if(!empty($pt['EnrolleeCoPerson']['EmailAddress'])) {
+        foreach($pt['EnrolleeCoPerson']['EmailAddress'] as $em) {
+          if(!$em['verified']) {
+            return $em;
+          }
+        }
+      }
+    }
+
+    // return null to indicate we did not find any unverified email addresses
+
+    return null;
+  }
+
+  /**
    * Send a confirmation (invite) for a Petition.
    * - postcondition: Invite sent
    *
@@ -2220,40 +2276,20 @@ class CoPetition extends AppModel {
    * @return String Address the invitation was sent to
    */
   
-  public function sendConfirmation($id, $actorCoPersonId) {
+  public function sendConfirmation($id, $ea, $actorCoPersonId) {
     // Just let any exceptions fall through
-    
+
     $args = array();
     $args['conditions']['CoPetition.id'] = $id;
     $args['contain']['EnrolleeCoPerson'][] = 'PrimaryName';
     $args['contain']['EnrolleeCoPerson']['CoPersonRole'][] = 'Cou';
     $args['contain']['EnrolleeCoPerson']['CoPersonRole']['SponsorCoPerson'][] = 'PrimaryName';
-    $args['contain']['EnrolleeOrgIdentity'] = array('EmailAddress', 'PrimaryName');
+    $args['contain']['EnrolleeOrgIdentity'] = array('PrimaryName');
     
     $pt = $this->find('first', $args);
     
     if(empty($pt)) {
       throw new InvalidArgumentException(_txt('er.notfound', array(_txt('ct.co_petitions.1'), $id)));
-    }
-    
-    if(empty($pt['EnrolleeOrgIdentity']['EmailAddress'])) {
-      throw new RuntimeException(_txt('er.orgp.nomail',
-                                      array(generateCn($pt['EnrolleeOrgIdentity']['PrimaryName']),
-                                            $pt['EnrolleeOrgIdentity']['id'])));
-    }
-    
-    $toEmail = null;
-    
-    // Which email do we pick? Ultimately we could look at type and/or verified,
-    // but for now we'll just pick the first one. sendApprovalNotification does similar.
-    // Note array_shift will muck with $pt, but we don't need it anymore.
-    
-    $ea = array_shift($pt['EnrolleeOrgIdentity']['EmailAddress']);
-    
-    if(empty($ea['mail'])) {
-      throw new RuntimeException(_txt('er.orgp.nomail',
-                                      array(generateCn($pt['EnrolleeOrgIdentity']['PrimaryName']),
-                                            $pt['EnrolleeOrgIdentity']['id'])));
     }
     
     $toEmail = $ea['mail'];
@@ -2314,7 +2350,7 @@ class CoPetition extends AppModel {
                                         $ef['Co']['name'],
                                         $subject,
                                         $body,
-                                        null,
+                                        $ea['id'],
                                         $ef['CoEnrollmentFlow']['invitation_validity'],
                                         $cc,
                                         $bcc,
@@ -3161,5 +3197,34 @@ class CoPetition extends AppModel {
     } else {
       return $ret;
     }
+  }
+
+  /**
+   * Ensure an enrollee token exists
+   *
+   * @since  COmanage Registry vTODO
+   * @param  id   CoPetition model id
+   */
+
+  public function ensureEnrolleeToken($id) {
+    $args=array();
+    $args['conditions']['CoPetition.id']=$id;
+    $model = $this->find('first', $args);
+
+    $token=null;
+    // if model is empty, disregard the request instead of throwing exceptions
+    if(!empty($model) && !empty($model['CoPetition'])) {
+      if(empty($model['CoPetition']['enrollee_token'])) {
+
+        $token = Security::generateAuthKey();
+        $this->id = $id;
+        $this->saveField('enrollee_token', $token);
+      }
+      else {
+        $token = $model['CoPetition']['enrollee_token'];
+      }
+    }
+
+    return $token;
   }
 }

--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -1540,7 +1540,10 @@ class CoPetition extends AppModel {
     
     // Set for future saveFields
     $this->id = $id;
-    
+
+    // create a cache of OIds for later use
+    $ois=array();
+
     // Obtain a list of attributes that are to be copied to the CO Person (Role) from the Org Identity
     
     $cArgs = array();
@@ -1952,7 +1955,10 @@ class CoPetition extends AppModel {
         } else {
           $dbc->rollback();
           throw new RuntimeException(_txt('er.db.save-a', array('CoOrgIdentityLink')));
-        }        
+        }
+
+        // cache the OrgIdentity ID for email matching later on
+        $ois[]=$porgid;
       }
     }
     
@@ -1983,6 +1989,15 @@ class CoPetition extends AppModel {
     // Commit
     $dbc->commit();
     
+    // Check to see if there are any email addresses set to both unverified and verified for the same
+    // set of OIs and CoPersonId. If a user enters the same address as verified through a trusted OIS,
+    // that address can be considered verified without testing
+    if(!empty($orgIdentityId)) {
+      // should never be empty at this stage
+      $ois[]=$orgIdentityId;
+    }
+    $this->EnrolleeCoPerson->EmailAddress->testVerifiedAddresses($ois,$coPersonId);
+
     return true;
   }
   

--- a/app/View/CoPetitions/petition-attributes.inc
+++ b/app/View/CoPetitions/petition-attributes.inc
@@ -266,7 +266,9 @@
 
           // Is the MVPA required? We'll just check the first attribute since they
           // should all be the same.
-          if($mvpa && $coe_attributes[0]['mvpa_required'] && $this->action != 'view') {
+          if( (($mvpa && $coe_attributes[0]['mvpa_required']) 
+              || (!$mvpa && $coe_attributes[0]['required']))
+             && $this->action != 'view') {
             print "<span class=\"required\">*</span>\n";
           }
           
@@ -349,7 +351,20 @@
                 $args['value'] = $ea['default'];
                 $args['disabled'] = !$ea['modifiable'];
               }
-              $args['empty'] = !$ea['required'];
+
+              // An attribute is required if (1) it is part of an MVPA that is required
+              // and the field itself is required, or (2) it is not part of an MVPA and
+              // the field itself is required
+              $args['required'] = false;
+              if(isset($ea['mvpa_required']) && $ea['mvpa_required']) {
+                  $args['required'] = $ea['required'];
+              } else {
+                $args['required'] = $ea['required'];
+              }
+
+              // Always show an empty field, even if required
+              // This forces users to choose (CO-1655)
+              $args['empty'] = '';
               $args['class'] = 'co-selectfield';
               $args['aria-label'] = $m;
 


### PR DESCRIPTION
This PR merges several feature/fix branches related to UvA reported issues into the SCZ HEAD:
co1647: only verify unverified addresses during enrollment
co1648: fix to allow users to verify their own email address
co1649: redirect to email view instead of logout after email confirmation
co1651: checking associated addresses (also on CoPerson) to propagate verification state after enrollment, in case of copied email addresses (issue #159918356)
co1655: allowing empty selection field, plus fixes in validation (related to issue #160127692: allow empty default for Affiliation selection during enrollment)

And a non-CO fix in a 'contains' specification to fix issue #159918321 (use of approval message template during enrollment).