### PR TITLE
Implementation of CO1650 

### DIFF
--- a/app/Controller/CoPeopleController.php
+++ b/app/Controller/CoPeopleController.php
@@ -785,6 +785,11 @@ class CoPeopleController extends StandardController {
     else
       $p['cous'] = array();
     
+
+    // CO-1650: only allow adding email addresses if there are any types set as self-serviceable
+    $email_address_types = $this->CoPerson->EmailAddress->defaultTypes('type');
+    $p['add_emailaddress'] = $p['edit'] && sizeof($email_address_types) > 0;
+
     $this->set('permissions', $p);
     return $p[$this->action];
   }

--- a/app/View/CoPeople/fields.inc
+++ b/app/View/CoPeople/fields.inc
@@ -617,7 +617,7 @@
           
           print $this->element('mvpa', $args);
           
-          $args['edit']         = $e;
+          $args['edit']         = $e && $permissions['add_emailaddress'];
           $args['self_service'] = true;
           $args['mvpa_model']   = 'EmailAddress';
           $args['mvpa_field']   = 'mail';


### PR DESCRIPTION
By adding an additional permission based on the number of self-serviceable email address types.

This effectively removes the Add button in the case as described by #157389676, so the user still cannot add an email address, but at least he/she does not get the impression that it would be available.