### PR TITLE
Fix for CO1665 

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1138,6 +1138,7 @@
     <field name="sync_on_update" type="L" />
     <field name="sync_on_delete" type="L" />
     <field name="create_role" type="L" />
+    <field name="link_name" type="L" />
     <field name="sync_cou_id" type="I">
       <constraint>REFERENCES cm_cous(id)</constraint>
     </field>

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -964,6 +964,25 @@ class CoPetitionsController extends StandardController {
             catch(Exception $e) {
 
             }
+          } else {
+            // if a pipeline created a CoPerson, link that to the petition instead
+            $this->linkCoPersonFromPipeline($id, $newOrgId['OrgIdentitySourceRecord']['org_identity_id']);
+
+            // If a pipeline created a person and/or role, the status was set to 'Active'.
+            // Correct this now, to avoid a situation where the enrollment is cut-off for
+            // some reason, but the CoPerson and the CoPersonRole are set active without
+            // approval
+            $coPersonId = $this->CoPetition->field('enrollee_co_person_id', array('CoPetition.id' => $id));
+            if(!empty($coPersonId)) {
+              $this->CoPetition->EnrolleeCoPerson->id = $coPersonId;
+              $this->CoPetition->EnrolleeCoPerson->saveField('status', StatusEnum::Pending, array('CoPetition.id' => $id));
+            }
+
+            $coPersonRoleId = $this->CoPetition->field('enrollee_co_person_role_id', array('CoPetition.id' => $id));
+            if(!empty($coPersonRoleId)) {
+              $this->CoPetition->EnrolleeCoPersonRole->id = $coPersonRoleId;
+              $this->CoPetition->EnrolleeCoPersonRole->saveField('status', StatusEnum::Pending, array('CoPetition.id' => $id));
+            }
           }
         }
       }
@@ -1469,6 +1488,55 @@ class CoPetitionsController extends StandardController {
     
     $this->redirect($this->generateDoneRedirect('selectEnrollee', $id));
   }
+
+  /**
+   * Link a pipeline-created CoPerson to the petition
+   *
+   * @since COmanage Registry vTODO
+   * @param Integer $id             CO Petition ID
+   * @param Integer $orgIdentityId  determined OrgIdentityId
+   */
+
+  protected function linkCoPersonFromPipeline($id, $orgIdentityId) {
+    // If we don't already have a CO Person, and if the OIS was attached
+    // to a pipeline and that pipeline created a CO Person we should attach
+    // that CO Person to the petition.
+
+    $pCoPersonId = $this->CoPetition->field('enrollee_co_person_id', array('CoPetition.id' => $id));
+    if(!$pCoPersonId) {
+      $pCoPersonId = $this->CoPetition
+                          ->EnrolleeOrgIdentity
+                          ->CoOrgIdentityLink
+                          ->field('co_person_id',
+                                  array('CoOrgIdentityLink.org_identity_id'
+                                        => $orgIdentityId));
+
+      if($pCoPersonId) {
+        // Link this CO Person ID to the petition
+        $this->CoPetition->linkCoPerson($this->cachedEnrollmentFlowID,
+                                        $id,
+                                        $pCoPersonId,
+                                        $this->Session->read('Auth.User.co_person_id'));
+
+        // If the pipeline created a new CoPersonRole as well, link that as well to the petition
+        // This will allow the petition controller to adjust the role status automatically based
+        // on the configuration
+
+        $args=array();
+        $args['conditions']['CoPersonRole.co_person_id']=$pCoPersonId;
+        $args['contains']=false;
+
+        $coPersonRole = $this->CoPetition->EnrolleeCoPerson->CoPersonRole->find('first',$args);
+
+        if(!empty($coPersonRole))
+        {
+          if(!$this->CoPetition->saveField('enrollee_co_person_role_id', $coPersonRole['CoPersonRole']['id'])) {
+            throw new RuntimeException(_txt('er.db.save'));
+          }
+        }
+      }
+    }
+  }
   
   /**
    * Execute CO Petition 'selectOrgIdentity' step
@@ -1510,30 +1578,8 @@ class CoPetitionsController extends StandardController {
                                              $id,
                                              $this->request->params['named']['orgidentityid'],
                                              $this->Session->read('Auth.User.co_person_id'));
-          
-          // If we don't already have a CO Person, and if the OIS was attached
-          // to a pipeline and that pipeline created a CO Person we should attach
-          // that CO Person to the petition.
-          
-          $pCoPersonId = $this->CoPetition->field('enrollee_co_person_id', array('CoPetition.id' => $id));
-          
-          if(!$pCoPersonId) {
-            $pCoPersonId = $this->CoPetition
-                                ->EnrolleeOrgIdentity
-                                ->CoOrgIdentityLink
-                                ->field('co_person_id',
-                                        array('CoOrgIdentityLink.org_identity_id'
-                                              => $this->request->params['named']['orgidentityid']));
-            
-            if($pCoPersonId) {
-              // Link this CO Person ID to the petition
-              
-              $this->CoPetition->linkCoPerson($this->cachedEnrollmentFlowID,
-                                              $id,
-                                              $pCoPersonId,
-                                              $this->Session->read('Auth.User.co_person_id'));
-            }
-          }
+
+          $this->linkCoPersonFromPipeline($id, $this->request->params['named']['orgidentityid']);
         } else {
           // Redirect into the OIS Selector
           

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1360,6 +1360,7 @@ original notification at
   'fd.pi.sync.role' => 'Create CO Person Role Record',
   'fd.pi.sync.str' => 'Sync Strategy',
   'fd.pi.sync.upd' => 'Sync on Update',
+  'fd.pi.sync.link' => 'Link Name',
   'fd.pipeline' =>    'Pipeline',
   'fd.pipeline.desc.ef' => 'Org Identities created directly (not via an Org Identity Source) from this Enrollment Flow will be processed using the specified Pipeline',
   'fd.pipeline.desc.ois' => 'Org Identities created from this Source will be processed using the specified Pipeline',

--- a/app/Model/CoPipeline.php
+++ b/app/Model/CoPipeline.php
@@ -110,6 +110,11 @@ class CoPipeline extends AppModel {
       'required'   => false,
       'allowEmpty' => true
     ),
+    'link_name' => array(
+      'rule'       => 'boolean',
+      'required'   => false,
+      'allowEmpty' => true
+    ),
     'create_role' => array(
       'rule'       => 'boolean',
       'required'   => false,
@@ -533,11 +538,15 @@ class CoPipeline extends AppModel {
         throw new RuntimeException(_txt('er.db.save-a', array('CoOrgIdentityLink')));
       }
       
-      // And create a Primary Name. We use the source's Primary Name here, but
-      // we don't actually link it to the source. This is in case the source record
-      // goes away and we want to ensure we still have a name record attached to the
-      // CO Person. (Under most circumstances the OIS name will be preserved, but eg
+      // And create a Primary Name. We use the source's Primary Name here.
+      // If 'link_name' is false, we do not actually link the name to the source.
+      // This is meant to cover cases where the source record goes away and we
+      // want to ensure we still have a name record attached to the CO Person.
+      // (Under most circumstances the OIS name will be preserved, but eg
       // an admin might try to clear out all associated data.)
+      //
+      // However, this also prevents updates of the name if the record does
+      // change on the OrgIdentity side (name corrections, marital status, etc.)
       
       $name = array(
         'Name' => array(
@@ -549,7 +558,7 @@ class CoPipeline extends AppModel {
           'suffix'         => $orgIdentity['PrimaryName']['suffix'],
           'type'           => $orgIdentity['PrimaryName']['type'],
           'primary_name'   => true,
-//          'source_name_id' => $orgIdentity['PrimaryName']['id'],
+          'source_name_id' => $coPipeline['CoPipeline']['link_name'] ? $orgIdentity['PrimaryName']['id'] : null,
         )
       );
       

--- a/app/View/CoPipelines/fields.inc
+++ b/app/View/CoPipelines/fields.inc
@@ -328,6 +328,17 @@
           </li>
           <li>
             <div class="field-name">
+              <div class="field-title"><?php print _txt('fd.pi.sync.link'); ?></div>
+            </div>
+            <div class="field-info checkbox">
+              <?php print ($e
+                           ? $this->Form->input('link_name') . ' ' .
+                             $this->Form->label('link_name', _txt('fd.pi.sync.link'))
+                           : (isset($co_pipelines[0]['CoPipeline']['link_name']) ? _txt('fd.yes') : _txt('fd.no'))); ?>
+            </div>
+          </li>
+          <li>
+            <div class="field-name">
               <div class="field-title"><?php print _txt('fd.pi.sync.role'); ?></div>
             </div>
             <div class="field-info checkbox">


### PR DESCRIPTION
We link the Pipeline created CoPerson and CoPersonRole to the petition after OrgIdentity creation by attached OIS plugins. This also introduces a 'link name' setting for Pipelines that allow linking the primary name specifically (which is otherwise explicitely not linked)