### PR TITLE
Fix to allow executing optional plugin steps

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -710,6 +710,10 @@ class CoPetitionsController extends StandardController {
             $redirect['token'] = $token;
           }
           
+          if($step == "start" && !empty($this->request->params['named']['return'])) {
+            $redirect['return'] = $this->request->params['named']['return'];
+          }
+
           $this->redirect($redirect);
           break;
         }
@@ -725,6 +729,10 @@ class CoPetitionsController extends StandardController {
         
         // Generate hint URL for where to go when the step is completed
         $onFinish = $this->generateDoneRedirect($step, $id, $curPlugin);
+        if($step == "start" && !empty($this->request->params['named']['return'])) {
+          $onFinish['return'] = $this->request->params['named']['return'];
+        }
+
         $this->set('vv_on_finish_url', $onFinish);
         
         // Run the step
@@ -785,6 +793,9 @@ class CoPetitionsController extends StandardController {
           
           // Make sure we don't issue a redirect
           return;
+        } else {
+          // Not in a plugin and this step is optional. Redirect to the plugin phase 
+          $this->redirect($onFinish);
         }
       }
     }


### PR DESCRIPTION
The fix also requires passing along the return URL parameter until all plugin steps for the start phase have executed. 
This is a non-essential change: as long as we do not have plugins that need the start phase to execute, the current code (which skips the phase) will do fine. This will break the FixedAttributeEnroller if the enrollment defines an introduction text (in which case the core-start phase is executed and the return parameter is not passed along). 
In that case this specific fix/change is required.