### PR TITLE
Fixes for templatemanager

### DIFF
--- a/app/Lib/enum.php
+++ b/app/Lib/enum.php
@@ -693,6 +693,12 @@ class TemplateableStatusEnum
   const Active              = 'A';
   const Suspended           = 'S';
   const Template            = 'T';
+
+  public static $from_api = array(
+    'Active'    => TemplateableStatusEnum::Active,
+    'Suspended' => TemplateableStatusEnum::Suspended,
+    'Template'  => TemplateableStatusEnum::Template
+  );
 }
 
 class UrlEnum {

--- a/app/Model/CoInvite.php
+++ b/app/Model/CoInvite.php
@@ -276,6 +276,7 @@ class CoInvite extends AppModel {
       $substitutions = array_merge($subs, array(
         'CO_NAME'   => $coName,
         'INVITE_URL' => Router::url(array(
+                                    'plugin'     => null,
                                     'controller' => 'co_invites',
                                     'action'     => 'reply',
                                     $invite['CoInvite']['invitation']

--- a/app/Model/OrgIdentity.php
+++ b/app/Model/OrgIdentity.php
@@ -258,24 +258,35 @@ class OrgIdentity extends AppModel {
     
     foreach(array_keys($this->hasOne) as $m)
     {
-      if($this->hasOne[$m]['dependent'])
+      if($this->hasOne[$m]['dependent'] && !in_array($m, array('OrgIdentitySourceRecord','PipelineCoPersonRole')))
       {
         foreach(array_keys($src[$m]) as $k)
         {
-          if($k != 'id' && $k != 'created' && $k != 'modified')
+          if($k != 'id' && $k != 'created' && $k != 'modified' && $k != 'OrgIdentity') {
             $new[$m][$k] = $src[$m][$k];
+          }
         }
       }
     }
-    
+
+    // An Org Identity can be attached to one or more CO Person
+    // The current design requires all links to be dropped manually
     foreach(array_keys($this->hasMany) as $m)
     {
-      if($this->hasMany[$m]['dependent'] && $m != 'CoPetition')
+      if($this->hasMany[$m]['dependent'] && !in_array($m, array('CoPetition', 'CoOrgIdentityLink','ArchivedCoPetition','HistoryRecord','PipelineCoGroupMember')))
       {
-        foreach(array_keys($src[$m]) as $k)
+        // numeric indexes
+        foreach($src[$m] as $model)
         {
-          if($k != 'id' && $k != 'created' && $k != 'modified')
-            $new[$m][$k] = $src[$m][$k];
+          $copy=array();
+          foreach($model as $k=>$v) {
+            if($k != 'id' && $k != 'created' && $k != 'modified' && $k != 'OrgIdentity') {
+              $copy[$k] = $v;
+            }
+          }
+          if(!empty($copy)) {
+            $new[$m][]=$copy;
+          }
         }
       }
     }


### PR DESCRIPTION
Backport fix from the hotfix-3.2.x branch to allow enums to be translated in the API.
Fix in CoInviteController to allow plugins to send invitations.
Fix in OrgIdentity to correctly implement the existing duplicate method and duplicate OrgIdentities between COs.