### PR TITLE
[Implements #164829717] Added format patterns 

### DIFF
--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1294,6 +1294,7 @@ original notification at
   'fd.ia.format.p1' => 'given.family(.#)@myvo.org',
   'fd.ia.format.p2' => 'given(.m).family(.#)@myvo.org',
   'fd.ia.format.p3' => 'gmf#@myvo.org',
+  'fd.ia.format.p4' => 'uid@co',
   'fd.ia.maximum' =>  'Maximum',
   'fd.ia.maximum.desc' => 'The maximum value for randomly generated identifiers',
   'fd.ia.minimum' =>  'Minimum',

--- a/app/View/CoIdentifierAssignments/fields.inc
+++ b/app/View/CoIdentifierAssignments/fields.inc
@@ -216,6 +216,7 @@
             <option value="(g).(f)[1:.(#)]@myvo.org"><?php print _txt('fd.ia.format.p1'); ?></option>
             <option value="(g)[1:.(m:1)].(f)[2:.(#)]@myvo.org"><?php print _txt('fd.ia.format.p2'); ?></option>
             <option value="(g:1)(m:1)(f:1)(#)@myvo.org"><?php print _txt('fd.ia.format.p3'); ?></option>
+            <option value="(I:uid)@(C)"><?php print _txt('fd.ia.format.p4'); ?></option>
           </select>
         <?php endif; ?>
       </div>


### PR DESCRIPTION
I (for identifier) and C (for CO-name). Implemented additional pattern parameters, colon separated. The first non-numeric one is interpreted as 'named' to identify a named identifier type. This allows (I:uid) to select an identifier of type 'UID' and (I:badge) to select one of type 'badge'. Width parameter for identifier should work as well, but defeats the purpose of an identifier