### PR TITLE
Checking for Primary Names

### DIFF
--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -1746,8 +1746,6 @@ class CoPetition extends AppModel {
         
         $coData['PrimaryName'] = $orgData['PrimaryName'];
       }
-
-      $this->checkModelForPrimaryName($coData);
     }
     
     if(!empty($coData)) {
@@ -1759,6 +1757,8 @@ class CoPetition extends AppModel {
       // Insert some additional attributes
       $coData['EnrolleeCoPerson']['co_id'] = $petition['CoPetition']['co_id'];
       $coData['EnrolleeCoPerson']['status'] = StatusEnum::Pending;
+
+      $this->checkModelForPrimaryName($coData);
       
       // Save the CO Person Data
       


### PR DESCRIPTION
After checking the enrollment attributes, just bef…ore saving them, all Names are checked to see if at least one of them is marked Primary. If not, the first Official, otherwise the first Preferred, otherwise any Name is marked Primary. If no Names are present, a name is provided (N.N.) and marked Primary.
[Fixes #165972929] 